### PR TITLE
Add stdio mode support for Claude Code integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,11 @@ uv run mypy toggl_track_mcp/           # Type checking
 
 ### Development Server
 ```bash
+# HTTP server mode (for web access)
 uv run uvicorn toggl_track_mcp.server:app --reload  # HTTP server at localhost:8000
+
+# stdio mode (for Claude Code integration)
+uv run python -m toggl_track_mcp  # MCP stdio server
 ```
 
 ### Test MCP Protocol
@@ -71,6 +75,35 @@ curl -X POST http://localhost:8000/mcp/ \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "get_current_user", "arguments": {}}, "id": 1}'
 ```
+
+## Claude Code Integration
+
+To use this MCP server with Claude Code, add this configuration to your Claude Code settings:
+
+```json
+{
+  "toggl-track": {
+    "command": "/Users/your-username/.local/bin/uv",
+    "args": [
+      "run",
+      "--directory",
+      "/path/to/toggl-track-mcp",
+      "python",
+      "-m",
+      "toggl_track_mcp"
+    ],
+    "env": {
+      "TOGGL_API_TOKEN": "your_toggl_api_token_here"
+    }
+  }
+}
+```
+
+**Setup steps:**
+1. Get your Toggl API token from https://track.toggl.com/profile
+2. Replace `/path/to/toggl-track-mcp` with the actual path to this repository
+3. Replace `your_toggl_api_token_here` with your actual API token
+4. Restart Claude Code
 
 ## Configuration Synchronization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "pre-commit>=3.0.0"
 ]
 
+[project.scripts]
+toggl-track-mcp = "toggl_track_mcp.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/fuzzylabs/toggl-track-mcp"
 Repository = "https://github.com/fuzzylabs/toggl-track-mcp.git"

--- a/toggl_track_mcp/__main__.py
+++ b/toggl_track_mcp/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for running Toggl Track MCP server in stdio mode."""
+
+import asyncio
+from .server import mcp
+
+def main():
+    """Run the MCP server in stdio mode."""
+    asyncio.run(mcp.run_stdio_async())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add stdio mode support for Claude Code integration by creating `__main__.py` entry point
- Add console script `toggl-track-mcp` in `pyproject.toml` for easy command-line execution
- Update `CLAUDE.md` with detailed Claude Code configuration section including environment setup
- Enables seamless integration with Claude Code's MCP client using stdio transport

## Test plan
- [x] Verify stdio mode entry point works: `python -m toggl_track_mcp`
- [x] Verify console script works: `toggl-track-mcp` (after installation)
- [x] Test Claude Code integration with provided configuration
- [x] Ensure existing HTTP mode functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)