### PR TITLE
feat: read Toggl custom reports via the Analytics API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,34 @@ This is a Model Context Protocol (MCP) server that exposes Toggl Track time trac
 - **Time Entries API**: Individual user time tracking data
 - **Reports API**: Team-wide time entries and summaries (admin access required)
 - **Workspace API**: Projects, clients, tags, and user management
+- **Analytics API**: Saved custom reports ("My Reports" dashboards) — see below
 
 ### Core Components
 
 - **`toggl_track_mcp/server.py`**: Main MCP server with FastMCP framework and FastAPI backend
 - **`toggl_track_mcp/toggl_client.py`**: Centralized Toggl API client with rate limiting and typed models
+- **`toggl_track_mcp/analytics.py`**: Models and pure helpers for the Analytics API (custom reports)
 - **`toggl_track_mcp/rate_limiter.py`**: Token bucket rate limiter for API requests
 - **`tests/`**: Test suite for server functionality and rate limiting
+
+### Analytics API (Custom Reports)
+
+Custom reports are organization-scoped dashboards served from
+`https://api.track.toggl.com/analytics/api`, not from the v9 or Reports v3 APIs. That API is
+undocumented — the endpoints were read out of the Toggl web app's own API client and verified
+against the live API — so keep it isolated behind `analytics.py` and `TogglAPIClient`'s
+`list_dashboards` / `get_dashboard` / `run_analytics_query` / `run_dashboard_chart` methods.
+
+Three behaviours differ from the rest of the API and are handled in `analytics.py`:
+
+- Durations are in **milliseconds**, not seconds. `resolve_rows` adds a `*_seconds` column.
+- The query engine returns a 500 (not a validation error) for `attributes` alongside `groupings`,
+  and for an `ordination` on a property that isn't grouped. `build_query` strips both; dropped
+  ordinations are applied locally by `sort_rows`.
+- Reports store a date **preset** (`prevMonth`, `thisQuarter`, …) rather than dates.
+  `resolve_period` mirrors the web app's preset definitions so a run covers the same days the UI does.
+
+`_make_request` takes a `base_url` override for this API; don't add a third copy of the httpx block.
 
 ### Tool Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,10 @@ Behaviours that differ from the rest of the API, all handled in `analytics.py`:
 
 - Durations are in **milliseconds**, not seconds. `resolve_rows` adds a `*_seconds` column.
 - The query engine returns a 500 (not a validation error) for `attributes` alongside `groupings`,
-  and for an `ordination` on a property that isn't grouped. `build_query` strips both; dropped
-  ordinations are applied locally by `sort_rows`, which must order numbers numerically because
-  those sorts are usually on an aggregate column.
+  and for an `ordination` on a property that isn't grouped. `build_query` strips both. If any
+  ordination can't be sent, the **whole** sequence is applied locally by `sort_rows` — sorting part
+  of it remotely and the rest afterwards would let a secondary key override the primary. `sort_rows`
+  must order numbers numerically, because those sorts are usually on an aggregate column.
 - A saved chart's `pagination` is dropped, because a paginated response carries no total count and
   would look complete. Omitting it returns the whole result set.
 - Reports store a date **preset** (`prevMonth`, `thisQuarter`, …) rather than dates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,22 @@ undocumented — the endpoints were read out of the Toggl web app's own API clie
 against the live API — so keep it isolated behind `analytics.py` and `TogglAPIClient`'s
 `list_dashboards` / `get_dashboard` / `run_analytics_query` / `run_dashboard_chart` methods.
 
-Three behaviours differ from the rest of the API and are handled in `analytics.py`:
+Behaviours that differ from the rest of the API, all handled in `analytics.py`:
 
 - Durations are in **milliseconds**, not seconds. `resolve_rows` adds a `*_seconds` column.
 - The query engine returns a 500 (not a validation error) for `attributes` alongside `groupings`,
   and for an `ordination` on a property that isn't grouped. `build_query` strips both; dropped
-  ordinations are applied locally by `sort_rows`.
+  ordinations are applied locally by `sort_rows`, which must order numbers numerically because
+  those sorts are usually on an aggregate column.
+- A saved chart's `pagination` is dropped, because a paginated response carries no total count and
+  would look complete. Omitting it returns the whole result set.
 - Reports store a date **preset** (`prevMonth`, `thisQuarter`, …) rather than dates.
-  `resolve_period` mirrors the web app's preset definitions so a run covers the same days the UI does.
+  `resolve_period` mirrors the web app's preset definitions so a run covers the same days the UI
+  does. For week-based presets the **report's** saved week start wins over the caller's, which is
+  only a fallback.
+- Report queries carry their own hourly quota (`x-toggl-quota-remaining`, ~240/hour). Don't spend
+  requests you don't need — `run_dashboard_chart` skips the `/me` lookup when given explicit dates,
+  and the resolved organization id is cached on the client.
 
 `_make_request` takes a `base_url` override for this API; don't add a third copy of the httpx block.
 

--- a/README.md
+++ b/README.md
@@ -315,11 +315,17 @@ read-only — these tools never modify a report.
 - Custom reports are scoped to an organization, resolved from your default workspace
 - Set `TOGGL_WORKSPACE_ID` to the workspace whose organization owns the reports
 
-**A custom report returns no rows, or fewer than the Toggl UI shows**
+**A custom report returns no rows, or a different total to the Toggl UI**
 - Check the period in the response: a report saved with a relative period (`Last month`) resolves
   against today's date, so it moves as the month does. Pass `start_date` and `end_date` to pin it
+- Week-based periods (`This week`) follow the week start saved on the report, not your own
 - Reports you can only view (rather than edit) still run, but a chart belonging to someone else's
   report cannot be fetched on its own
+
+**"Quota exceeded" or custom reports failing after heavy use**
+- Report queries have their own hourly quota, around 240 queries, separate from the API rate limit
+- Each `run_custom_report` call spends one; run a report once and reuse the rows rather than
+  calling it per question
 
 **"Report uses a custom date range but has no dates saved"**
 - The report was saved with a custom period Toggl did not store dates for

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Custom reports are the multi-chart dashboards built in Toggl's **My Reports** se
 | `run_custom_report` | Runs one chart and returns its rows, with IDs resolved to names and durations in seconds |
 
 `run_custom_report` uses the report's own saved date period (`Last month`, `This quarter` and so on)
-unless you pass `start_date` and `end_date`. A report with several charts runs one at a time — pass
+unless you pass both `start_date` and `end_date`. A report with several charts runs one at a time — pass
 the `chart_id` from `get_custom_report` to pick a specific one, or omit it for the first chart.
 
 ### Example Custom Report Queries

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Transform how you work with your Toggl Track time tracking data by asking AI ass
 - *"Create a new time entry for 'Meeting with client'"* **(Write mode only)**
 - *"Start a timer for 'Working on feature X'"* **(Write mode only)**
 - *"Create a new client called 'Acme Corp' with the note 'Q3 SOW pending'"*
-- *"Create a new project AIaaS-200-3001 for client 47847188, billable, starting 2026-05-01, ending 2026-08-31, 120 estimated hours"*
-- *"Add Sam (user 11551609) and Tiffany (user 12299621) to project 213632529"*
+- *"Create a new project ACME-200-3001 for client 101, billable, starting 2026-05-01, ending 2026-08-31, 120 estimated hours"*
+- *"Add Alex (user 202) and Jordan (user 203) to project 3001"*
 
 **🔒 Secure by Default** — Read-only access with optional write mode via environment variable
 **🚀 Instant Setup** — Works with any MCP-compatible AI assistant  

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Transform how you work with your Toggl Track time tracking data by asking AI ass
 - *"Show me team time entries for the past month"* **(Admin only)**
 - *"Generate a team summary grouped by users"* **(Admin only)**
 - *"List all workspace users and their IDs"* **(Admin only)**
+- *"List our saved custom reports"*
+- *"Run the 'Client time by team' custom report for June"*
+- *"What does the client time custom report measure?"*
 - *"Create a new time entry for 'Meeting with client'"* **(Write mode only)**
 - *"Start a timer for 'Working on feature X'"* **(Write mode only)**
 - *"Create a new client called 'Acme Corp' with the note 'Q3 SOW pending'"*
@@ -222,6 +225,7 @@ This MCP server provides **complete access** to your Toggl Track data:
 | **🏢 Workspaces** | View available workspaces and permissions |
 | **🏷️ Tags** | Browse all tags for categorization |
 | **📈 Analytics** | Generate time summaries, breakdowns, reports |
+| **📋 Custom Reports** | List saved "My Reports" dashboards, read their definitions, and run them for any date range |
 | **👥 Team Reports** | **(Admin only)** Access team-wide time entries, summaries, and user data |
 | **🔍 Workspace Users** | **(Admin only)** List all workspace members with IDs for filtering |
 
@@ -255,6 +259,31 @@ Try these with admin permissions:
 
 **⚠️ Important**: Team features only work if your Toggl Track account has workspace admin permissions. Regular users will receive appropriate error messages when attempting to access team data.
 
+## Custom Reports
+
+Custom reports are the multi-chart dashboards built in Toggl's **My Reports** section — the ones at
+`track.toggl.com/reports/{organization_id}/custom/{report_id}`. Three tools cover them:
+
+| **Tool** | **What it does** |
+|---|---|
+| `list_custom_reports` | Lists the organization's saved reports with their IDs, chart types and saved date period |
+| `get_custom_report` | Shows a report's definition: each chart's groupings, aggregations and filters |
+| `run_custom_report` | Runs one chart and returns its rows, with IDs resolved to names and durations in seconds |
+
+`run_custom_report` uses the report's own saved date period (`Last month`, `This quarter` and so on)
+unless you pass `start_date` and `end_date`. A report with several charts runs one at a time — pass
+the `chart_id` from `get_custom_report` to pick a specific one, or omit it for the first chart.
+
+### Example Custom Report Queries
+- *"List our custom reports"*
+- *"Run custom report 12345 for July 2026"*
+- *"Which clients did the engineering team log time against last month?"*
+
+**⚠️ Unofficial API**: Toggl serves custom reports from an `analytics` API that is not part of its
+published API documentation. It authenticates with the same API token, and the endpoints were
+verified against the live API, but Toggl can change them without notice. Everything here is
+read-only — these tools never modify a report.
+
 ## Troubleshooting
 
 ### Common Issues
@@ -281,6 +310,20 @@ Try these with admin permissions:
 - Team features require workspace admin permissions in Toggl Track
 - Check your role: Profile Settings → Workspaces → your workspace → check if you're an admin
 - Contact your workspace owner to grant admin access if needed
+
+**Custom reports return "No organization found for workspace"**
+- Custom reports are scoped to an organization, resolved from your default workspace
+- Set `TOGGL_WORKSPACE_ID` to the workspace whose organization owns the reports
+
+**A custom report returns no rows, or fewer than the Toggl UI shows**
+- Check the period in the response: a report saved with a relative period (`Last month`) resolves
+  against today's date, so it moves as the month does. Pass `start_date` and `end_date` to pin it
+- Reports you can only view (rather than edit) still run, but a chart belonging to someone else's
+  report cannot be fetched on its own
+
+**"Report uses a custom date range but has no dates saved"**
+- The report was saved with a custom period Toggl did not store dates for
+- Pass `start_date` and `end_date` to `run_custom_report`
 
 **MCP tools not showing in your AI assistant**
 - Restart your AI assistant after config changes

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -99,6 +99,34 @@ class TestPeriodForDashboard:
             dashboard, start_date="2026-01-01", end_date="2026-01-31"
         ) == {"from": "2026-01-01", "to": "2026-01-31"}
 
+    @pytest.mark.parametrize(
+        "start_date,end_date",
+        [("2026-01-01", None), (None, "2026-01-31")],
+    )
+    def test_explicit_dates_must_be_provided_together(self, start_date, end_date):
+        with pytest.raises(ValueError, match="must be provided together"):
+            period_for_dashboard(
+                TogglAnalyticsDashboard(id=1),
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+    def test_explicit_dates_must_be_ordered(self):
+        with pytest.raises(ValueError, match="on or before"):
+            period_for_dashboard(
+                TogglAnalyticsDashboard(id=1),
+                start_date="2026-08-01",
+                end_date="2026-07-31",
+            )
+
+    def test_explicit_dates_must_be_valid_iso_dates(self):
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            period_for_dashboard(
+                TogglAnalyticsDashboard(id=1),
+                start_date="2026-02-30",
+                end_date="2026-03-01",
+            )
+
     def test_saved_preset_is_resolved(self):
         dashboard = TogglAnalyticsDashboard(
             id=1, preferences={"datePeriod": {"preset": "prevMonth"}}
@@ -211,12 +239,12 @@ class TestBuildQuery:
 
         assert query["attributes"] == [{"property": "duration"}]
 
-    def test_ordination_on_ungrouped_property_is_returned_for_local_sorting(self):
+    def test_mixed_ordinations_are_all_returned_for_local_sorting(self):
         chart = self._chart(
             groupings=[{"property": "client_id"}],
             ordinations=[
-                {"property": "client_name", "direction": "ASC"},
                 {"property": "client_id", "direction": "DESC"},
+                {"property": "client_name", "direction": "ASC"},
             ],
         )
 
@@ -224,8 +252,22 @@ class TestBuildQuery:
             TogglAnalyticsDashboard(id=1), chart, {"from": "a"}
         )
 
-        assert query["ordinations"] == [{"property": "client_id", "direction": "DESC"}]
-        assert dropped == [{"property": "client_name", "direction": "ASC"}]
+        assert "ordinations" not in query
+        assert dropped == [
+            {"property": "client_id", "direction": "DESC"},
+            {"property": "client_name", "direction": "ASC"},
+        ]
+
+    def test_grouped_ordinations_stay_remote(self):
+        ordinations = [{"property": "client_id", "direction": "DESC"}]
+        chart = self._chart(
+            groupings=[{"property": "client_id"}], ordinations=ordinations
+        )
+
+        query, local = build_query(TogglAnalyticsDashboard(id=1), chart, {"from": "a"})
+
+        assert query["ordinations"] == ordinations
+        assert local == []
 
     def test_all_ordinations_dropped_removes_the_key(self):
         chart = self._chart(
@@ -360,6 +402,27 @@ class TestSortRows:
         ordered = sort_rows(rows, [{"property": "value", "direction": "ASC"}])
 
         assert [row["value"] for row in ordered] == [2, 10, "beta"]
+
+    def test_multiple_ordinations_preserve_primary_key_priority(self):
+        rows = [
+            {"client_id": 2, "client_name": "Zeta"},
+            {"client_id": 1, "client_name": "Alpha"},
+            {"client_id": 2, "client_name": "Alpha"},
+        ]
+
+        ordered = sort_rows(
+            rows,
+            [
+                {"property": "client_id", "direction": "DESC"},
+                {"property": "client_name", "direction": "ASC"},
+            ],
+        )
+
+        assert [(row["client_id"], row["client_name"]) for row in ordered] == [
+            (2, "Alpha"),
+            (2, "Zeta"),
+            (1, "Alpha"),
+        ]
 
     def test_unknown_column_is_ignored(self):
         rows = [{"client_name": "Zeta"}, {"client_name": "Alpha"}]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -118,6 +118,24 @@ class TestPeriodForDashboard:
             "to": "2026-08-08",
         }
 
+    def test_saved_week_start_beats_the_callers(self):
+        """The report defines the week, whoever runs it."""
+        dashboard = TogglAnalyticsDashboard(
+            id=1,
+            preferences={"datePeriod": {"preset": "thisWeek"}, "begginingOfWeek": 0},
+        )
+        assert period_for_dashboard(
+            dashboard, today=TODAY, fallback_beginning_of_week=1
+        ) == {"from": "2026-08-02", "to": "2026-08-08"}
+
+    def test_fallback_week_start_used_when_report_saves_none(self):
+        dashboard = TogglAnalyticsDashboard(
+            id=1, preferences={"datePeriod": {"preset": "thisWeek"}}
+        )
+        assert period_for_dashboard(
+            dashboard, today=TODAY, fallback_beginning_of_week=0
+        ) == {"from": "2026-08-02", "to": "2026-08-08"}
+
     def test_saved_custom_range(self):
         dashboard = TogglAnalyticsDashboard(
             id=1,
@@ -222,6 +240,14 @@ class TestBuildQuery:
         assert "ordinations" not in query
         assert len(dropped) == 1
 
+    def test_pagination_removed(self):
+        """A saved page size would return one page with no way to detect more."""
+        chart = self._chart(pagination={"page": 1, "per_page": 50})
+
+        query, _ = build_query(TogglAnalyticsDashboard(id=1), chart, {"from": "a"})
+
+        assert "pagination" not in query
+
     def test_v3_query_params_removed(self):
         chart = self._chart(v3_query_params=None, groupings=[])
 
@@ -310,6 +336,31 @@ class TestSortRows:
 
         assert ordered[-1] == {"other": 1}
 
+    def test_numeric_columns_sort_numerically(self):
+        """Aggregates are the usual locally-sorted column; 900 is not > 1000."""
+        rows = [{"sum_duration": 900}, {"sum_duration": 1000}, {"sum_duration": 90}]
+
+        ordered = sort_rows(rows, [{"property": "sum_duration", "direction": "DESC"}])
+
+        assert [row["sum_duration"] for row in ordered] == [1000, 900, 90]
+
+    def test_numeric_ascending_with_nulls_last(self):
+        rows = [{"sum_duration": 1000}, {"other": 1}, {"sum_duration": 90}]
+
+        ordered = sort_rows(
+            rows,
+            [{"property": "sum_duration", "direction": "ASC", "nulls": "last"}],
+        )
+
+        assert [row.get("sum_duration") for row in ordered] == [90, 1000, None]
+
+    def test_mixed_types_do_not_raise(self):
+        rows = [{"value": 10}, {"value": "beta"}, {"value": 2}]
+
+        ordered = sort_rows(rows, [{"property": "value", "direction": "ASC"}])
+
+        assert [row["value"] for row in ordered] == [2, 10, "beta"]
+
     def test_unknown_column_is_ignored(self):
         rows = [{"client_name": "Zeta"}, {"client_name": "Alpha"}]
 
@@ -340,6 +391,11 @@ class TestSummariseRows:
         assert totals["sum_duration"] == 3500
         assert totals["count"] == 5
         assert totals["sum_duration_seconds"] == 3
+
+    def test_only_exact_count_column_is_totalled(self):
+        totals = summarise_rows([{"count": 2, "country": 7}])
+
+        assert totals == {"count": 2}
 
     def test_no_duration_column(self):
         assert summarise_rows([{"count": 1}]) == {"count": 1}

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,348 @@
+"""Tests for the Analytics API helpers (custom reports)."""
+
+from datetime import date
+
+import pytest
+
+from toggl_track_mcp.analytics import (
+    TogglAnalyticsChart,
+    TogglAnalyticsDashboard,
+    build_query,
+    period_for_dashboard,
+    resolve_period,
+    resolve_rows,
+    sort_rows,
+    summarise_rows,
+)
+
+# A Monday, so week boundaries are unambiguous in the assertions below.
+TODAY = date(2026, 8, 3)
+
+
+class TestResolvePeriod:
+    """Preset date ranges must match the ones the Toggl UI uses."""
+
+    @pytest.mark.parametrize(
+        "preset,expected",
+        [
+            ("today", ("2026-08-03", "2026-08-03")),
+            ("yesterday", ("2026-08-02", "2026-08-02")),
+            ("thisWeek", ("2026-08-03", "2026-08-09")),
+            ("prevWeek", ("2026-07-27", "2026-08-02")),
+            ("weekToDate", ("2026-08-03", "2026-08-03")),
+            ("last2Weeks", ("2026-07-20", "2026-08-02")),
+            ("thisMonth", ("2026-08-01", "2026-08-31")),
+            ("prevMonth", ("2026-07-01", "2026-07-31")),
+            ("monthToDate", ("2026-08-01", "2026-08-03")),
+            ("thisQuarter", ("2026-07-01", "2026-09-30")),
+            ("quarterToDate", ("2026-07-01", "2026-08-03")),
+            ("lastQuarter", ("2026-04-01", "2026-06-30")),
+            ("thisSemester", ("2026-07-01", "2026-12-31")),
+            ("semesterToDate", ("2026-07-01", "2026-08-03")),
+            ("lastSemester", ("2026-01-01", "2026-06-30")),
+            ("last30Days", ("2026-07-05", "2026-08-03")),
+            ("last90Days", ("2026-05-06", "2026-08-03")),
+            ("last12Months", ("2025-09-01", "2026-08-31")),
+            ("thisYear", ("2026-01-01", "2026-12-31")),
+            ("yearToDate", ("2026-01-01", "2026-08-03")),
+            ("prevYear", ("2025-01-01", "2025-12-31")),
+            ("allTime", ("2006-01-01", "2028-12-31")),
+        ],
+    )
+    def test_presets(self, preset, expected):
+        assert resolve_period(preset, today=TODAY) == expected
+
+    def test_missing_preset_defaults_to_this_month(self):
+        assert resolve_period(None, today=TODAY) == ("2026-08-01", "2026-08-31")
+        assert resolve_period("", today=TODAY) == ("2026-08-01", "2026-08-31")
+
+    def test_week_starting_sunday(self):
+        assert resolve_period("thisWeek", today=TODAY, beginning_of_week=0) == (
+            "2026-08-02",
+            "2026-08-08",
+        )
+
+    def test_custom_uses_supplied_dates(self):
+        assert resolve_period(
+            "custom",
+            today=TODAY,
+            custom_from="2026-01-15",
+            custom_to="2026-02-15",
+        ) == ("2026-01-15", "2026-02-15")
+
+    def test_custom_without_dates_raises(self):
+        with pytest.raises(ValueError, match="custom date range"):
+            resolve_period("custom", today=TODAY)
+
+    def test_unknown_preset_raises(self):
+        with pytest.raises(ValueError, match="Unknown date preset"):
+            resolve_period("sinceTheDawnOfTime", today=TODAY)
+
+    def test_month_end_clamping(self):
+        """A 31st does not roll into the next month when shifting back."""
+        assert resolve_period("prevMonth", today=date(2026, 3, 31)) == (
+            "2026-02-01",
+            "2026-02-28",
+        )
+
+    def test_defaults_to_current_date(self):
+        start, end = resolve_period("today")
+        assert start == end == date.today().isoformat()
+
+
+class TestPeriodForDashboard:
+    def test_explicit_dates_win(self):
+        dashboard = TogglAnalyticsDashboard(
+            id=1, preferences={"datePeriod": {"preset": "prevMonth"}}
+        )
+        assert period_for_dashboard(
+            dashboard, start_date="2026-01-01", end_date="2026-01-31"
+        ) == {"from": "2026-01-01", "to": "2026-01-31"}
+
+    def test_saved_preset_is_resolved(self):
+        dashboard = TogglAnalyticsDashboard(
+            id=1, preferences={"datePeriod": {"preset": "prevMonth"}}
+        )
+        assert period_for_dashboard(dashboard, today=TODAY) == {
+            "from": "2026-07-01",
+            "to": "2026-07-31",
+        }
+
+    def test_saved_week_start_is_honoured(self):
+        dashboard = TogglAnalyticsDashboard(
+            id=1,
+            preferences={"datePeriod": {"preset": "thisWeek"}, "begginingOfWeek": 0},
+        )
+        assert period_for_dashboard(dashboard, today=TODAY) == {
+            "from": "2026-08-02",
+            "to": "2026-08-08",
+        }
+
+    def test_saved_custom_range(self):
+        dashboard = TogglAnalyticsDashboard(
+            id=1,
+            preferences={
+                "datePeriod": {
+                    "preset": "custom",
+                    "from": "2026-05-01",
+                    "to": "2026-05-31",
+                }
+            },
+        )
+        assert period_for_dashboard(dashboard, today=TODAY) == {
+            "from": "2026-05-01",
+            "to": "2026-05-31",
+        }
+
+    def test_no_preferences_falls_back_to_this_month(self):
+        assert period_for_dashboard(TogglAnalyticsDashboard(id=1), today=TODAY) == {
+            "from": "2026-08-01",
+            "to": "2026-08-31",
+        }
+
+
+class TestBuildQuery:
+    def _chart(self, **query):
+        return TogglAnalyticsChart(id=9, type="table", query=query)
+
+    def test_merges_report_filters_and_period(self):
+        dashboard = TogglAnalyticsDashboard(
+            id=1,
+            filters=[
+                {
+                    "operator": "and",
+                    "value": None,
+                    "conditions": [
+                        {"property": "user_id", "operator": "in", "value": [7]}
+                    ],
+                }
+            ],
+        )
+        chart = self._chart(
+            groupings=[{"property": "client_id"}],
+            aggregations=[{"function": "sum", "property": "duration"}],
+            filters=[{"property": "workspace_id", "operator": "=", "value": 456}],
+        )
+
+        query, dropped = build_query(
+            dashboard, chart, {"from": "2026-07-01", "to": "2026-07-31"}
+        )
+
+        assert query["period"] == {"from": "2026-07-01", "to": "2026-07-31"}
+        assert query["filters"] == [
+            {"property": "workspace_id", "operator": "=", "value": 456},
+            dashboard.filters[0],
+        ]
+        assert dropped == []
+
+    def test_attributes_dropped_when_grouped(self):
+        """The query engine 500s on attributes alongside groupings."""
+        chart = self._chart(
+            groupings=[{"property": "client_id"}],
+            attributes=[{"property": "duration"}],
+        )
+
+        query, _ = build_query(TogglAnalyticsDashboard(id=1), chart, {"from": "a"})
+
+        assert "attributes" not in query
+
+    def test_attributes_kept_without_grouping(self):
+        chart = self._chart(attributes=[{"property": "duration"}])
+
+        query, _ = build_query(TogglAnalyticsDashboard(id=1), chart, {"from": "a"})
+
+        assert query["attributes"] == [{"property": "duration"}]
+
+    def test_ordination_on_ungrouped_property_is_returned_for_local_sorting(self):
+        chart = self._chart(
+            groupings=[{"property": "client_id"}],
+            ordinations=[
+                {"property": "client_name", "direction": "ASC"},
+                {"property": "client_id", "direction": "DESC"},
+            ],
+        )
+
+        query, dropped = build_query(
+            TogglAnalyticsDashboard(id=1), chart, {"from": "a"}
+        )
+
+        assert query["ordinations"] == [{"property": "client_id", "direction": "DESC"}]
+        assert dropped == [{"property": "client_name", "direction": "ASC"}]
+
+    def test_all_ordinations_dropped_removes_the_key(self):
+        chart = self._chart(
+            groupings=[{"property": "client_id"}],
+            ordinations=[{"property": "client_name", "direction": "ASC"}],
+        )
+
+        query, dropped = build_query(
+            TogglAnalyticsDashboard(id=1), chart, {"from": "a"}
+        )
+
+        assert "ordinations" not in query
+        assert len(dropped) == 1
+
+    def test_v3_query_params_removed(self):
+        chart = self._chart(v3_query_params=None, groupings=[])
+
+        query, _ = build_query(TogglAnalyticsDashboard(id=1), chart, {"from": "a"})
+
+        assert "v3_query_params" not in query
+
+    def test_chart_query_is_not_mutated(self):
+        chart = self._chart(groupings=[{"property": "client_id"}])
+        original = dict(chart.query)
+
+        build_query(TogglAnalyticsDashboard(id=1), chart, {"from": "a"})
+
+        assert chart.query == original
+
+    def test_empty_chart_query(self):
+        query, dropped = build_query(
+            TogglAnalyticsDashboard(id=1), TogglAnalyticsChart(id=9), {"from": "a"}
+        )
+
+        assert query == {"period": {"from": "a"}}
+        assert dropped == []
+
+
+class TestResolveRows:
+    def test_ids_resolved_and_durations_converted(self):
+        rows = [{"client_id": 101, "user_id": 202, "sum_duration": 22200000}]
+        dictionaries = {
+            "clients": {"101": {"id": 101, "name": "Acme Corp"}},
+            "users": {"202": {"id": 202, "name": "Alex"}},
+        }
+
+        resolved = resolve_rows(rows, dictionaries)
+
+        assert resolved[0]["client_name"] == "Acme Corp"
+        assert resolved[0]["user_name"] == "Alex"
+        assert resolved[0]["sum_duration_seconds"] == 22200
+        assert resolved[0]["sum_duration"] == 22200000
+
+    def test_missing_dictionary_entry_is_left_alone(self):
+        resolved = resolve_rows([{"client_id": 1, "sum_duration": 1000}], {})
+
+        assert "client_name" not in resolved[0]
+        assert resolved[0]["sum_duration_seconds"] == 1
+
+    def test_null_id_is_not_resolved(self):
+        resolved = resolve_rows([{"client_id": None}], {"clients": {}})
+
+        assert "client_name" not in resolved[0]
+
+    def test_plain_string_dictionary_values(self):
+        resolved = resolve_rows([{"user_id": 3}], {"users": {"3": "Alex"}})
+
+        assert resolved[0]["user_name"] == "Alex"
+
+    def test_no_dictionaries_argument(self):
+        assert resolve_rows([{"count": 2}]) == [{"count": 2}]
+
+
+class TestSortRows:
+    def test_sorts_by_resolved_name(self):
+        rows = [{"client_name": "Zeta"}, {"client_name": "Alpha"}]
+
+        ordered = sort_rows(rows, [{"property": "client_name", "direction": "ASC"}])
+
+        assert [row["client_name"] for row in ordered] == ["Alpha", "Zeta"]
+
+    def test_descending(self):
+        rows = [{"client_name": "Alpha"}, {"client_name": "Zeta"}]
+
+        ordered = sort_rows(rows, [{"property": "client_name", "direction": "DESC"}])
+
+        assert [row["client_name"] for row in ordered] == ["Zeta", "Alpha"]
+
+    def test_nulls_first_by_default(self):
+        rows = [{"client_name": "Alpha"}, {"other": 1}]
+
+        ordered = sort_rows(rows, [{"property": "client_name", "nulls": "first"}])
+
+        assert ordered[0] == {"other": 1}
+
+    def test_nulls_last(self):
+        rows = [{"other": 1}, {"client_name": "Alpha"}]
+
+        ordered = sort_rows(rows, [{"property": "client_name", "nulls": "last"}])
+
+        assert ordered[-1] == {"other": 1}
+
+    def test_unknown_column_is_ignored(self):
+        rows = [{"client_name": "Zeta"}, {"client_name": "Alpha"}]
+
+        ordered = sort_rows(rows, [{"property": "nope", "direction": "ASC"}])
+
+        assert ordered == rows
+
+    def test_ordination_without_property_is_ignored(self):
+        rows = [{"client_name": "Zeta"}]
+
+        assert sort_rows(rows, [{"direction": "ASC"}]) == rows
+
+    def test_no_ordinations_returns_rows_unchanged(self):
+        rows = [{"client_name": "Zeta"}]
+
+        assert sort_rows(rows, []) == rows
+
+
+class TestSummariseRows:
+    def test_totals_numeric_aggregates(self):
+        rows = [
+            {"sum_duration": 1000, "count": 2, "client_name": "A"},
+            {"sum_duration": 2500, "count": 3, "client_name": "B"},
+        ]
+
+        totals = summarise_rows(rows)
+
+        assert totals["sum_duration"] == 3500
+        assert totals["count"] == 5
+        assert totals["sum_duration_seconds"] == 3
+
+    def test_no_duration_column(self):
+        assert summarise_rows([{"count": 1}]) == {"count": 1}
+
+    def test_empty_rows(self):
+        assert summarise_rows([]) == {}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,10 @@ from toggl_track_mcp.toggl_client import (
     TogglReportsResponse,
     TogglReportTimeEntry,
 )
+from toggl_track_mcp.analytics import (
+    TogglAnalyticsChart,
+    TogglAnalyticsDashboard,
+)
 
 
 @pytest.fixture
@@ -1479,3 +1483,204 @@ async def test_add_project_user_error_handling():
 
         assert "error" in result
         assert result["error"] == "API Error"
+
+
+# Tests for custom reports (Analytics API)
+
+
+def create_mock_dashboard():
+    """Create a mock custom report with one table chart."""
+    return TogglAnalyticsDashboard(
+        id=12345,
+        organization_id=999,
+        name="Client time by team",
+        pinned=False,
+        preferences={"datePeriod": {"preset": "prevMonth"}},
+        filters=[{"property": "user_id", "operator": "in", "value": [7]}],
+        chart_summary={"chart_details": [{"chart_type": "table", "chart_id": 51}]},
+        charts=[
+            TogglAnalyticsChart(
+                id=51,
+                type="table",
+                query={
+                    "groupings": [{"property": "client_id"}],
+                    "aggregations": [{"function": "sum", "property": "duration"}],
+                    "filters": [
+                        {"property": "workspace_id", "operator": "=", "value": 456}
+                    ],
+                },
+            )
+        ],
+        creator_name="Test User",
+        updated_at="2026-07-07T16:25:06Z",
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_custom_reports_success():
+    """Test successful list_custom_reports execution."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.list_dashboards.return_value = [create_mock_dashboard()]
+        mock_get_client.return_value = mock_client
+
+        result = await server.list_custom_reports.fn()
+
+        assert "error" not in result
+        assert result["total_count"] == 1
+        report = result["custom_reports"][0]
+        assert report["id"] == 12345
+        assert report["name"] == "Client time by team"
+        assert report["chart_count"] == 1
+        assert report["chart_types"] == ["table"]
+        assert report["date_preset"] == "prevMonth"
+
+
+@pytest.mark.asyncio
+async def test_list_custom_reports_only_pinned():
+    """Test list_custom_reports passes the pinned filter through."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.list_dashboards.return_value = []
+        mock_get_client.return_value = mock_client
+
+        result = await server.list_custom_reports.fn(only_pinned=True)
+
+        mock_client.list_dashboards.assert_awaited_once_with(only_pinned=True)
+        assert result["total_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_custom_reports_error_handling():
+    """Test list_custom_reports error handling."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_get_client.side_effect = TogglAPIError("API Error")
+
+        result = await server.list_custom_reports.fn()
+
+        assert result["error"] == "API Error"
+
+
+@pytest.mark.asyncio
+async def test_get_custom_report_success():
+    """Test successful get_custom_report execution."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get_dashboard.return_value = create_mock_dashboard()
+        mock_get_client.return_value = mock_client
+
+        result = await server.get_custom_report.fn(report_id=12345)
+
+        assert "error" not in result
+        report = result["report"]
+        assert report["name"] == "Client time by team"
+        assert report["report_filters"] == [
+            {"property": "user_id", "operator": "in", "value": [7]}
+        ]
+        chart = report["charts"][0]
+        assert chart["chart_id"] == 51
+        assert chart["groupings"] == ["client_id"]
+        assert chart["aggregations"] == ["sum(duration)"]
+
+
+@pytest.mark.asyncio
+async def test_get_custom_report_error_handling():
+    """Test get_custom_report error handling."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_get_client.side_effect = TogglAPIError("Not found")
+
+        result = await server.get_custom_report.fn(report_id=1)
+
+        assert result["error"] == "Not found"
+
+
+@pytest.mark.asyncio
+async def test_run_custom_report_success():
+    """Test successful run_custom_report execution."""
+    chart_data = {
+        "report_id": 12345,
+        "report_name": "Client time by team",
+        "chart_id": 51,
+        "chart_type": "table",
+        "period": {"from": "2026-07-01", "to": "2026-07-31"},
+        "rows": [
+            {
+                "client_id": 1,
+                "client_name": "Acme Corp",
+                "sum_duration": 7200000,
+                "sum_duration_seconds": 7200,
+            }
+        ],
+        "totals": {"sum_duration": 7200000, "sum_duration_seconds": 7200},
+        "query": {},
+    }
+
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.run_dashboard_chart.return_value = chart_data
+        mock_client.format_duration = MagicMock(return_value="2h 0m")
+        mock_get_client.return_value = mock_client
+
+        result = await server.run_custom_report.fn(report_id=12345)
+
+        assert "error" not in result
+        assert result["row_count"] == 1
+        assert result["rows"][0]["duration_formatted"] == "2h 0m"
+        assert result["totals"]["duration_formatted"] == "2h 0m"
+        assert "2026-07-01 to 2026-07-31" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_run_custom_report_passes_overrides():
+    """Test run_custom_report forwards chart and date overrides."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.run_dashboard_chart.return_value = {
+            "report_id": 1,
+            "report_name": "R",
+            "chart_id": 52,
+            "chart_type": "bar",
+            "period": {"from": "2026-01-01", "to": "2026-01-31"},
+            "rows": [],
+            "totals": {},
+            "query": {},
+        }
+        mock_get_client.return_value = mock_client
+
+        result = await server.run_custom_report.fn(
+            report_id=1, chart_id=52, start_date="2026-01-01", end_date="2026-01-31"
+        )
+
+        mock_client.run_dashboard_chart.assert_awaited_once_with(
+            dashboard_id=1,
+            chart_id=52,
+            start_date="2026-01-01",
+            end_date="2026-01-31",
+        )
+        assert result["row_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_custom_report_error_handling():
+    """Test run_custom_report error handling."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_get_client.side_effect = TogglAPIError("API Error")
+
+        result = await server.run_custom_report.fn(report_id=1)
+
+        assert result["error"] == "API Error"
+
+
+@pytest.mark.asyncio
+async def test_run_custom_report_unresolvable_date_range():
+    """Test run_custom_report reports an unresolvable saved date range."""
+    with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.run_dashboard_chart.side_effect = ValueError(
+            "Report uses a custom date range but has no dates saved."
+        )
+        mock_get_client.return_value = mock_client
+
+        result = await server.run_custom_report.fn(report_id=1)
+
+        assert "custom date range" in result["error"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1417,7 +1417,7 @@ async def test_add_project_user_success():
     mock_response = {
         "id": 9001,
         "project_id": 555,
-        "user_id": 12299621,
+        "user_id": 202,
         "workspace_id": 456,
         "manager": False,
     }
@@ -1427,18 +1427,18 @@ async def test_add_project_user_success():
         mock_api_client.add_project_user.return_value = mock_response
         mock_get_client.return_value = mock_api_client
 
-        result = await server.add_project_user.fn(project_id=555, user_id=12299621)
+        result = await server.add_project_user.fn(project_id=555, user_id=202)
 
         assert "error" not in result
         assert "project_user" in result
         assert result["project_user"]["project_id"] == 555
-        assert result["project_user"]["user_id"] == 12299621
-        assert "12299621" in result["message"]
+        assert result["project_user"]["user_id"] == 202
+        assert "202" in result["message"]
         assert "555" in result["message"]
 
         mock_api_client.add_project_user.assert_called_once_with(
             project_id=555,
-            user_id=12299621,
+            user_id=202,
             manager=False,
         )
 
@@ -1479,7 +1479,7 @@ async def test_add_project_user_error_handling():
     with patch("toggl_track_mcp.server._get_toggl_client") as mock_get_client:
         mock_get_client.side_effect = TogglAPIError("API Error")
 
-        result = await server.add_project_user.fn(project_id=555, user_id=12299621)
+        result = await server.add_project_user.fn(project_id=555, user_id=202)
 
         assert "error" in result
         assert result["error"] == "API Error"

--- a/tests/test_toggl_client.py
+++ b/tests/test_toggl_client.py
@@ -1,8 +1,11 @@
 """Tests for Toggl API client."""
 
-import pytest
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
 import httpx
+import pytest
 
 from toggl_track_mcp.toggl_client import (
     TogglAPIClient,
@@ -1301,6 +1304,36 @@ class TestAnalyticsAPI:
         period = result["period"]
         assert period["from"].endswith("-01")
         assert run.call_args.args[1]["period"] == period
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_resolves_period_in_users_timezone(
+        self, client, dashboard_payload
+    ):
+        user = TogglUser(
+            id=123,
+            email="test@example.com",
+            fullname="Test",
+            timezone="Pacific/Honolulu",
+            default_workspace_id=456,
+            beginning_of_week=1,
+            created_at="2023-01-01T00:00:00Z",
+            updated_at="2023-01-01T00:00:00Z",
+        )
+        user_now = datetime(2026, 7, 31, 23, 30, tzinfo=ZoneInfo(user.timezone))
+
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch("toggl_track_mcp.toggl_client.datetime") as datetime_mock:
+                datetime_mock.now.return_value = user_now
+                with patch.object(
+                    client, "run_analytics_query", return_value={"data_json_row": []}
+                ):
+                    result = await client.run_dashboard_chart(
+                        12345,
+                        dashboard=TogglAnalyticsDashboard(**dashboard_payload),
+                    )
+
+        datetime_mock.now.assert_called_once_with(ZoneInfo(user.timezone))
+        assert result["period"] == {"from": "2026-06-01", "to": "2026-06-30"}
 
     @pytest.mark.asyncio
     async def test_run_dashboard_chart_selects_requested_chart(

--- a/tests/test_toggl_client.py
+++ b/tests/test_toggl_client.py
@@ -16,6 +16,11 @@ from toggl_track_mcp.toggl_client import (
     TogglReportsResponse,
     TogglReportTimeEntry,
 )
+from toggl_track_mcp.analytics import (
+    ANALYTICS_BASE_URL,
+    TogglAnalyticsChart,
+    TogglAnalyticsDashboard,
+)
 
 
 @pytest.fixture
@@ -1100,3 +1105,262 @@ class TestCreateTimeEntry:
                     await client.create_time_entry("Test entry")
                 
                 assert "Invalid response format for created time entry" in str(exc_info.value)
+
+
+class TestAnalyticsAPI:
+    """Test the Analytics API methods behind custom reports."""
+
+    @pytest.fixture
+    def user(self):
+        return TogglUser(
+            id=123,
+            email="test@example.com",
+            fullname="Test",
+            timezone="UTC",
+            default_workspace_id=456,
+            beginning_of_week=1,
+            created_at="2023-01-01T00:00:00Z",
+            updated_at="2023-01-01T00:00:00Z",
+        )
+
+    @pytest.fixture
+    def dashboard_payload(self):
+        return {
+            "id": 12345,
+            "organization_id": 999,
+            "name": "Client time by team",
+            "preferences": {"datePeriod": {"preset": "prevMonth"}},
+            "filters": [
+                {
+                    "operator": "and",
+                    "value": None,
+                    "conditions": [
+                        {"property": "user_id", "operator": "in", "value": [7]}
+                    ],
+                }
+            ],
+            "chart_summary": {
+                "chart_details": [{"chart_type": "table", "chart_id": 51}]
+            },
+            "charts": [
+                {
+                    "id": 51,
+                    "type": "table",
+                    "query": {
+                        "groupings": [{"property": "client_id"}],
+                        "aggregations": [{"function": "sum", "property": "duration"}],
+                        "filters": [
+                            {"property": "workspace_id", "operator": "=", "value": 456}
+                        ],
+                    },
+                },
+                {
+                    "id": 52,
+                    "type": "bar",
+                    "query": {"groupings": [{"property": "day"}]},
+                },
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_organization_id(self, client, user):
+        workspaces = [TogglWorkspace(id=123, organization_id=999)]
+
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(client, "get_workspaces", return_value=workspaces):
+                assert await client.get_organization_id() == 999
+
+    @pytest.mark.asyncio
+    async def test_get_organization_id_not_found(self, client, user):
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(client, "get_workspaces", return_value=[]):
+                with pytest.raises(TogglAPIError) as exc_info:
+                    await client.get_organization_id()
+
+                assert "No organization found for workspace 123" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_list_dashboards(self, client, dashboard_payload):
+        with patch.object(
+            client, "_make_request", return_value=[dashboard_payload]
+        ) as request:
+            with patch.object(client, "get_organization_id", return_value=999):
+                dashboards = await client.list_dashboards()
+
+        assert len(dashboards) == 1
+        assert dashboards[0].name == "Client time by team"
+        assert request.call_args.kwargs["params"] == {"organization_id": 999}
+        assert request.call_args.kwargs["base_url"] == ANALYTICS_BASE_URL
+
+    @pytest.mark.asyncio
+    async def test_list_dashboards_only_pinned(self, client, dashboard_payload):
+        with patch.object(client, "_make_request", return_value=[]) as request:
+            await client.list_dashboards(organization_id=999, only_pinned=True)
+
+        assert request.call_args.kwargs["params"]["pinned"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_list_dashboards_invalid_response(self, client):
+        with patch.object(client, "_make_request", return_value={}):
+            with pytest.raises(TogglAPIError) as exc_info:
+                await client.list_dashboards(organization_id=999)
+
+            assert "Invalid response format for custom reports" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_dashboard(self, client, dashboard_payload):
+        with patch.object(client, "_make_request", return_value=dashboard_payload):
+            dashboard = await client.get_dashboard(12345)
+
+        assert dashboard.id == 12345
+        assert len(dashboard.charts) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_dashboard_invalid_response(self, client):
+        with patch.object(client, "_make_request", return_value=[]):
+            with pytest.raises(TogglAPIError) as exc_info:
+                await client.get_dashboard(1)
+
+            assert "Invalid response format for custom report" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_analytics_query(self, client):
+        with patch.object(
+            client, "_make_request", return_value={"data_json_row": []}
+        ) as request:
+            result = await client.run_analytics_query(999, {"period": {"from": "a"}})
+
+        assert result == {"data_json_row": []}
+        assert request.call_args.kwargs["params"] == {
+            "response_format": "json_row",
+            "include_dicts": "true",
+        }
+        assert request.call_args.args == ("POST", "/organizations/999/query")
+
+    @pytest.mark.asyncio
+    async def test_run_analytics_query_without_dicts(self, client):
+        with patch.object(client, "_make_request", return_value={}) as request:
+            await client.run_analytics_query(999, {}, include_dicts=False)
+
+        assert request.call_args.kwargs["params"]["include_dicts"] == "false"
+
+    @pytest.mark.asyncio
+    async def test_run_analytics_query_invalid_response(self, client):
+        with patch.object(client, "_make_request", return_value=[]):
+            with pytest.raises(TogglAPIError) as exc_info:
+                await client.run_analytics_query(999, {})
+
+            assert "Invalid response format for analytics query" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_defaults_to_first_chart(
+        self, client, user, dashboard_payload
+    ):
+        query_response = {
+            "data_json_row": [{"client_id": 1, "sum_duration": 7200000}],
+            "dictionaries": {"clients": {"1": {"id": 1, "name": "Acme Corp"}}},
+        }
+
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(
+                client,
+                "get_dashboard",
+                return_value=TogglAnalyticsDashboard(**dashboard_payload),
+            ):
+                with patch.object(
+                    client, "run_analytics_query", return_value=query_response
+                ) as run:
+                    result = await client.run_dashboard_chart(
+                        12345, start_date="2026-07-01", end_date="2026-07-31"
+                    )
+
+        assert result["chart_id"] == 51
+        assert result["period"] == {"from": "2026-07-01", "to": "2026-07-31"}
+        assert result["rows"][0]["client_name"] == "Acme Corp"
+        assert result["totals"]["sum_duration_seconds"] == 7200
+
+        sent_query = run.call_args.args[1]
+        assert sent_query["filters"][-1] == dashboard_payload["filters"][0]
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_resolves_saved_period(
+        self, client, user, dashboard_payload
+    ):
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(
+                client,
+                "get_dashboard",
+                return_value=TogglAnalyticsDashboard(**dashboard_payload),
+            ):
+                with patch.object(
+                    client, "run_analytics_query", return_value={"data_json_row": []}
+                ) as run:
+                    result = await client.run_dashboard_chart(12345)
+
+        # prevMonth resolves to a full calendar month
+        period = result["period"]
+        assert period["from"].endswith("-01")
+        assert run.call_args.args[1]["period"] == period
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_selects_requested_chart(
+        self, client, user, dashboard_payload
+    ):
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(
+                client, "run_analytics_query", return_value={"data_json_row": []}
+            ):
+                result = await client.run_dashboard_chart(
+                    12345,
+                    chart_id=52,
+                    dashboard=TogglAnalyticsDashboard(**dashboard_payload),
+                )
+
+        assert result["chart_id"] == 52
+        assert result["chart_type"] == "bar"
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_unknown_chart(
+        self, client, user, dashboard_payload
+    ):
+        with patch.object(
+            client,
+            "get_dashboard",
+            return_value=TogglAnalyticsDashboard(**dashboard_payload),
+        ):
+            with pytest.raises(TogglAPIError) as exc_info:
+                await client.run_dashboard_chart(12345, chart_id=99)
+
+            assert "Chart 99 is not part of custom report" in str(exc_info.value)
+            assert "51, 52" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_without_charts(self, client):
+        with patch.object(
+            client, "get_dashboard", return_value=TogglAnalyticsDashboard(id=1)
+        ):
+            with pytest.raises(TogglAPIError) as exc_info:
+                await client.run_dashboard_chart(1)
+
+            assert "has no charts" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_resolves_organization(self, client, user):
+        dashboard = TogglAnalyticsDashboard(
+            id=1, charts=[TogglAnalyticsChart(id=51, type="table", query={})]
+        )
+
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(client, "get_organization_id", return_value=999) as org:
+                with patch.object(
+                    client, "run_analytics_query", return_value={}
+                ) as run:
+                    await client.run_dashboard_chart(
+                        1,
+                        start_date="2026-07-01",
+                        end_date="2026-07-31",
+                        dashboard=dashboard,
+                    )
+
+        org.assert_awaited_once()
+        assert run.call_args.args[0] == 999

--- a/tests/test_toggl_client.py
+++ b/tests/test_toggl_client.py
@@ -1364,3 +1364,104 @@ class TestAnalyticsAPI:
 
         org.assert_awaited_once()
         assert run.call_args.args[0] == 999
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_skips_user_lookup_for_explicit_dates(
+        self, client, dashboard_payload
+    ):
+        """Only a relative preset needs the caller's week start."""
+        dashboard = TogglAnalyticsDashboard(**dashboard_payload)
+
+        with patch.object(client, "get_current_user") as user_lookup:
+            with patch.object(client, "run_analytics_query", return_value={}):
+                await client.run_dashboard_chart(
+                    12345,
+                    start_date="2026-07-01",
+                    end_date="2026-07-31",
+                    dashboard=dashboard,
+                )
+
+        user_lookup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_dashboard_chart_uses_reports_own_week_start(self, client, user):
+        """A week-based preset covers the report's week, not the caller's."""
+        dashboard = TogglAnalyticsDashboard(
+            id=1,
+            organization_id=999,
+            preferences={"datePeriod": {"preset": "thisWeek"}, "begginingOfWeek": 0},
+            charts=[TogglAnalyticsChart(id=51, type="bar", query={})],
+        )
+
+        with patch.object(client, "get_current_user", return_value=user):
+            with patch.object(client, "run_analytics_query", return_value={}) as run:
+                result = await client.run_dashboard_chart(1, dashboard=dashboard)
+
+        # user.beginning_of_week is 1 (Monday); the report says 0 (Sunday)
+        from datetime import date, timedelta
+
+        expected_start = date.today() - timedelta(days=(date.today().weekday() + 1) % 7)
+        assert result["period"]["from"] == expected_start.isoformat()
+        assert run.call_args.args[1]["period"] == result["period"]
+
+    @pytest.mark.asyncio
+    async def test_get_organization_id_is_cached(self, client, user):
+        workspaces = [TogglWorkspace(id=123, organization_id=999)]
+
+        with patch.object(client, "get_current_user", return_value=user) as user_lookup:
+            with patch.object(client, "get_workspaces", return_value=workspaces):
+                assert await client.get_organization_id() == 999
+                assert await client.get_organization_id() == 999
+
+        user_lookup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_organization_id_explicit_workspace_is_not_cached(self, client):
+        workspaces = [
+            TogglWorkspace(id=123, organization_id=999),
+            TogglWorkspace(id=456, organization_id=888),
+        ]
+
+        with patch.object(client, "get_workspaces", return_value=workspaces):
+            assert await client.get_organization_id(workspace_id=456) == 888
+
+        assert client._organization_id is None
+
+
+class TestClientErrorsAreNotRetried:
+    """A 4xx will fail identically on retry, so it should surface immediately."""
+
+    @pytest.mark.asyncio
+    async def test_client_error_raises_without_retrying(self, client):
+        request = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Error",
+                request=MagicMock(),
+                response=MagicMock(status_code=403, text="Forbidden"),
+            )
+        )
+        with patch("httpx.AsyncClient") as mock_httpx:
+            mock_httpx.return_value.__aenter__.return_value.request = request
+
+            with pytest.raises(TogglAPIError) as exc_info:
+                await client._make_request("GET", "/test")
+
+        assert exc_info.value.status_code == 403
+        assert request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_server_error_still_retries(self, client):
+        request = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Error",
+                request=MagicMock(),
+                response=MagicMock(status_code=500, text="Server Error"),
+            )
+        )
+        with patch("httpx.AsyncClient") as mock_httpx:
+            mock_httpx.return_value.__aenter__.return_value.request = request
+            with patch("asyncio.sleep", new=AsyncMock()):
+                with pytest.raises(TogglAPIError):
+                    await client._make_request("GET", "/test", retries=2)
+
+        assert request.await_count == 3

--- a/toggl_track_mcp/analytics.py
+++ b/toggl_track_mcp/analytics.py
@@ -1,0 +1,381 @@
+"""Helpers for Toggl's Analytics API (custom reports).
+
+Custom reports are the multi-chart dashboards behind
+``track.toggl.com/reports/{organization_id}/custom/{dashboard_id}``. They are
+served by Toggl's ``analytics`` API, which is **not** part of the published
+Reports API v3 documentation and has no OpenAPI spec. Everything here was
+derived from the Toggl web app's own API client and verified against the live
+API. It authenticates with the ordinary API token, but treat it as unversioned:
+Toggl can change it without notice.
+
+Two quirks of that API shape the code below:
+
+* Durations come back in **milliseconds**, unlike Reports v3 which uses seconds.
+* The query engine rejects some field combinations a saved chart may contain:
+  ``attributes`` alongside ``groupings``, and ``ordinations`` on a property that
+  is not grouped (a ``client_name`` sort on a ``client_id`` grouping, for
+  instance). Both return a 500 rather than a validation error, so
+  :func:`build_query` strips them and the ordering is applied locally instead.
+
+This module holds only pure functions and models. The HTTP calls live on
+``TogglAPIClient`` in ``toggl_client.py``.
+"""
+
+import calendar
+from datetime import date, timedelta
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict
+
+ANALYTICS_BASE_URL = "https://api.track.toggl.com/analytics/api"
+
+#: Earliest date the Toggl web app uses for its "all time" preset.
+ALL_TIME_START = date(2006, 1, 1)
+
+#: Maps an id column in a result row to the dictionary that names it.
+_DICTIONARY_FOR_COLUMN = {
+    "client_id": "clients",
+    "group_id": "user_groups",
+    "project_id": "projects",
+    "tag_id": "tags",
+    "task_id": "tasks",
+    "user_group_id": "user_groups",
+    "user_id": "users",
+    "workspace_id": "workspaces",
+}
+
+
+class TogglAnalyticsChart(BaseModel):
+    """A single chart within a custom report."""
+
+    id: Optional[int] = None
+    organization_id: Optional[int] = None
+    name: Optional[str] = None
+    type: Optional[str] = None
+    pinned: Optional[bool] = None
+    preferences: Optional[Dict[str, Any]] = None
+    query: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    creator_name: Optional[str] = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class TogglAnalyticsDashboard(BaseModel):
+    """A custom report ("dashboard") and the charts it contains."""
+
+    id: Optional[int] = None
+    organization_id: Optional[int] = None
+    name: Optional[str] = None
+    pinned: Optional[bool] = None
+    locked: Optional[bool] = None
+    preferences: Optional[Dict[str, Any]] = None
+    filters: Optional[List[Dict[str, Any]]] = None
+    grid_items: Optional[List[Dict[str, Any]]] = None
+    charts: Optional[List[TogglAnalyticsChart]] = None
+    chart_summary: Optional[Dict[str, Any]] = None
+    link: Optional[Dict[str, Any]] = None
+    permissions: Optional[List[Dict[str, Any]]] = None
+    created_by: Optional[int] = None
+    creator_name: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+def _add_months(day: date, months: int) -> date:
+    """Shift a date by whole months, clamping to the end of the target month."""
+    month_index = day.month - 1 + months
+    year = day.year + month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, min(day.day, calendar.monthrange(year, month)[1]))
+
+
+def _start_of_month(day: date) -> date:
+    return day.replace(day=1)
+
+
+def _end_of_month(day: date) -> date:
+    return day.replace(day=calendar.monthrange(day.year, day.month)[1])
+
+
+def _start_of_week(day: date, beginning_of_week: int) -> date:
+    """Start of the week containing ``day``.
+
+    ``beginning_of_week`` follows Toggl's convention: 0 is Sunday, 1 is Monday.
+    """
+    offset = (day.weekday() - (beginning_of_week - 1)) % 7
+    return day - timedelta(days=offset)
+
+
+def _start_of_quarter(day: date) -> date:
+    return date(day.year, 3 * ((day.month - 1) // 3) + 1, 1)
+
+
+def _start_of_semester(day: date) -> date:
+    """First day of the current half-year (January or July)."""
+    return date(day.year, 1 if day.month <= 6 else 7, 1)
+
+
+def resolve_period(
+    preset: Optional[str],
+    today: Optional[date] = None,
+    beginning_of_week: int = 1,
+    custom_from: Optional[str] = None,
+    custom_to: Optional[str] = None,
+) -> Tuple[str, str]:
+    """Resolve a Toggl date preset into an inclusive ``(from, to)`` date pair.
+
+    The ranges mirror the web app's own preset definitions so a report run
+    through this client covers the same days it does in the UI.
+
+    Args:
+        preset: Preset name, e.g. ``prevMonth``. ``custom`` uses the explicit
+            dates. ``None`` is treated as ``thisMonth``, matching the app's
+            behaviour for a report saved without a period.
+        today: Reference date (defaults to the current date).
+        beginning_of_week: 0 for Sunday, 1 for Monday.
+        custom_from: Start date for the ``custom`` preset (YYYY-MM-DD).
+        custom_to: End date for the ``custom`` preset (YYYY-MM-DD).
+
+    Raises:
+        ValueError: If the preset is unknown, or ``custom`` is missing dates.
+    """
+    day = today or date.today()
+    week_start = _start_of_week(day, beginning_of_week)
+    semester_start = _start_of_semester(day)
+    quarter_start = _start_of_quarter(day)
+
+    if preset in (None, ""):
+        preset = "thisMonth"
+
+    if preset == "custom":
+        if not custom_from or not custom_to:
+            raise ValueError(
+                "Report uses a custom date range but has no dates saved. "
+                "Pass start_date and end_date."
+            )
+        return custom_from, custom_to
+
+    ranges: Dict[str, Tuple[date, date]] = {
+        "today": (day, day),
+        "yesterday": (day - timedelta(days=1), day - timedelta(days=1)),
+        "thisWeek": (week_start, week_start + timedelta(days=6)),
+        "prevWeek": (week_start - timedelta(days=7), week_start - timedelta(days=1)),
+        "weekToDate": (week_start, day),
+        "last2Weeks": (week_start - timedelta(days=14), week_start - timedelta(days=1)),
+        "thisMonth": (_start_of_month(day), _end_of_month(day)),
+        "prevMonth": (
+            _start_of_month(_add_months(_start_of_month(day), -1)),
+            _end_of_month(_add_months(_start_of_month(day), -1)),
+        ),
+        "monthToDate": (_start_of_month(day), day),
+        "thisQuarter": (
+            quarter_start,
+            _end_of_month(_add_months(quarter_start, 2)),
+        ),
+        "quarterToDate": (quarter_start, day),
+        "lastQuarter": (
+            _add_months(quarter_start, -3),
+            quarter_start - timedelta(days=1),
+        ),
+        "thisSemester": (
+            semester_start,
+            _end_of_month(_add_months(semester_start, 5)),
+        ),
+        "semesterToDate": (semester_start, day),
+        "lastSemester": (
+            _add_months(semester_start, -6),
+            semester_start - timedelta(days=1),
+        ),
+        "last30Days": (day - timedelta(days=29), day),
+        "last90Days": (day - timedelta(days=89), day),
+        "last12Months": (
+            _start_of_month(_add_months(day, -11)),
+            _end_of_month(day),
+        ),
+        "thisYear": (date(day.year, 1, 1), date(day.year, 12, 31)),
+        "yearToDate": (date(day.year, 1, 1), day),
+        "prevYear": (date(day.year - 1, 1, 1), date(day.year - 1, 12, 31)),
+        "allTime": (ALL_TIME_START, date(day.year + 2, 12, 31)),
+    }
+
+    if preset not in ranges:
+        raise ValueError(
+            f"Unknown date preset '{preset}'. Pass start_date and end_date instead."
+        )
+
+    start, end = ranges[preset]
+    return start.isoformat(), end.isoformat()
+
+
+def period_for_dashboard(
+    dashboard: TogglAnalyticsDashboard,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    today: Optional[date] = None,
+    beginning_of_week: Optional[int] = None,
+) -> Dict[str, str]:
+    """Work out the date window to run a report over.
+
+    Explicit dates win; otherwise the report's saved preset is resolved.
+    """
+    if start_date and end_date:
+        return {"from": start_date, "to": end_date}
+
+    preferences = dashboard.preferences or {}
+    date_period = preferences.get("datePeriod") or {}
+    if beginning_of_week is None:
+        # Toggl's own field name carries this typo.
+        beginning_of_week = preferences.get("begginingOfWeek", 1)
+
+    resolved_from, resolved_to = resolve_period(
+        date_period.get("preset"),
+        today=today,
+        beginning_of_week=beginning_of_week if beginning_of_week is not None else 1,
+        custom_from=date_period.get("from") or start_date,
+        custom_to=date_period.get("to") or end_date,
+    )
+    return {"from": start_date or resolved_from, "to": end_date or resolved_to}
+
+
+def _grouped_properties(query: Dict[str, Any]) -> List[str]:
+    return [
+        grouping.get("property")
+        for grouping in query.get("groupings") or []
+        if grouping.get("property")
+    ]
+
+
+def build_query(
+    dashboard: TogglAnalyticsDashboard,
+    chart: TogglAnalyticsChart,
+    period: Dict[str, str],
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Build an analytics query payload for one chart of a custom report.
+
+    Merges the chart's saved query with the report-level filters and the
+    resolved period, and removes the field combinations the query engine
+    rejects.
+
+    Returns:
+        The payload, and the ordinations that were removed so the caller can
+        apply them to the returned rows instead.
+    """
+    query: Dict[str, Any] = dict(chart.query or {})
+    query["period"] = period
+
+    filters: List[Dict[str, Any]] = list(query.get("filters") or [])
+    filters.extend(dashboard.filters or [])
+    if filters:
+        query["filters"] = filters
+
+    groupings = _grouped_properties(query)
+
+    # An `attributes` list is only valid on an ungrouped (detail) query.
+    if groupings:
+        query.pop("attributes", None)
+
+    # Sorts on a property that isn't grouped are applied locally instead.
+    local_ordinations: List[Dict[str, Any]] = []
+    if query.get("ordinations"):
+        remote = []
+        for ordination in query["ordinations"]:
+            if ordination.get("property") in groupings:
+                remote.append(ordination)
+            else:
+                local_ordinations.append(ordination)
+        if remote:
+            query["ordinations"] = remote
+        else:
+            query.pop("ordinations", None)
+
+    query.pop("v3_query_params", None)
+
+    return query, local_ordinations
+
+
+def _dictionary_name(
+    dictionaries: Dict[str, Any], dictionary: str, entity_id: Any
+) -> Optional[str]:
+    entries = dictionaries.get(dictionary) or {}
+    entry = entries.get(str(entity_id))
+    if isinstance(entry, dict):
+        name = entry.get("name")
+        return str(name) if name is not None else None
+    if entry is not None:
+        return str(entry)
+    return None
+
+
+def resolve_rows(
+    rows: List[Dict[str, Any]],
+    dictionaries: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Turn raw result rows into readable ones.
+
+    Adds a ``*_name`` for every id column the response has a dictionary for,
+    and converts millisecond durations to seconds.
+    """
+    dictionaries = dictionaries or {}
+    resolved: List[Dict[str, Any]] = []
+
+    for row in rows:
+        item = dict(row)
+        for column, value in row.items():
+            dictionary = _DICTIONARY_FOR_COLUMN.get(column)
+            if dictionary and value is not None:
+                name = _dictionary_name(dictionaries, dictionary, value)
+                if name is not None:
+                    item[column.replace("_id", "_name")] = name
+            if column.endswith("duration") and isinstance(value, (int, float)):
+                item[f"{column}_seconds"] = int(value) // 1000
+        resolved.append(item)
+
+    return resolved
+
+
+def _sort_value(column: str, row: Dict[str, Any]) -> str:
+    value = row.get(column)
+    return "" if value is None else str(value).lower()
+
+
+def sort_rows(
+    rows: List[Dict[str, Any]], ordinations: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Apply ordinations the query engine could not, ignoring unknown columns."""
+    ordered = list(rows)
+
+    for ordination in reversed(ordinations):
+        prop = ordination.get("property")
+        if not prop or not any(prop in row for row in ordered):
+            continue
+        column = str(prop)
+        descending = str(ordination.get("direction", "ASC")).upper() == "DESC"
+        nulls_last = str(ordination.get("nulls", "first")).lower() == "last"
+
+        ordered.sort(key=partial(_sort_value, column), reverse=descending)
+
+        # Null placement is independent of direction, so position it after the
+        # sort rather than letting `reverse` flip it.
+        missing = [row for row in ordered if row.get(column) is None]
+        if missing:
+            present = [row for row in ordered if row.get(column) is not None]
+            ordered = present + missing if nulls_last else missing + present
+
+    return ordered
+
+
+def summarise_rows(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Total the numeric aggregate columns across rows."""
+    totals: Dict[str, Any] = {}
+    for row in rows:
+        for column, value in row.items():
+            if column.startswith(("sum_", "count")) and isinstance(value, (int, float)):
+                totals[column] = totals.get(column, 0) + value
+    if "sum_duration" in totals:
+        totals["sum_duration_seconds"] = int(totals["sum_duration"]) // 1000
+    return totals

--- a/toggl_track_mcp/analytics.py
+++ b/toggl_track_mcp/analytics.py
@@ -8,7 +8,7 @@ derived from the Toggl web app's own API client and verified against the live
 API. It authenticates with the ordinary API token, but treat it as unversioned:
 Toggl can change it without notice.
 
-Two quirks of that API shape the code below:
+Quirks of that API shape the code below:
 
 * Durations come back in **milliseconds**, unlike Reports v3 which uses seconds.
 * The query engine rejects some field combinations a saved chart may contain:
@@ -16,6 +16,12 @@ Two quirks of that API shape the code below:
   is not grouped (a ``client_name`` sort on a ``client_id`` grouping, for
   instance). Both return a 500 rather than a validation error, so
   :func:`build_query` strips them and the ordering is applied locally instead.
+* A saved chart may carry the page size the UI renders it with, and a paginated
+  response carries no total count. :func:`build_query` drops it so the whole
+  result set comes back rather than a page that looks complete.
+* Queries are quota'd separately from the rest of the API: responses carry
+  ``x-toggl-quota-remaining`` and ``x-toggl-quota-resets-in``, measured at 240
+  queries per hour. Worth keeping in mind before running a report in a loop.
 
 This module holds only pure functions and models. The HTTP calls live on
 ``TogglAPIClient`` in ``toggl_client.py``.
@@ -217,25 +223,41 @@ def period_for_dashboard(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     today: Optional[date] = None,
-    beginning_of_week: Optional[int] = None,
+    fallback_beginning_of_week: Optional[int] = None,
 ) -> Dict[str, str]:
     """Work out the date window to run a report over.
 
     Explicit dates win; otherwise the report's saved preset is resolved.
+
+    Args:
+        dashboard: The report, whose preferences hold the preset and week start
+        start_date: Overrides the resolved start date
+        end_date: Overrides the resolved end date
+        today: Reference date for relative presets (defaults to the current date)
+        fallback_beginning_of_week: Week start to use when the report does not
+            save one. The report's own setting always takes precedence, so that
+            a week-based preset covers the same days it does in the UI whoever
+            runs it.
     """
     if start_date and end_date:
         return {"from": start_date, "to": end_date}
 
     preferences = dashboard.preferences or {}
     date_period = preferences.get("datePeriod") or {}
-    if beginning_of_week is None:
-        # Toggl's own field name carries this typo.
-        beginning_of_week = preferences.get("begginingOfWeek", 1)
+
+    # Toggl's own field name carries this typo.
+    saved_beginning_of_week = preferences.get("begginingOfWeek")
+    if saved_beginning_of_week is not None:
+        beginning_of_week = saved_beginning_of_week
+    elif fallback_beginning_of_week is not None:
+        beginning_of_week = fallback_beginning_of_week
+    else:
+        beginning_of_week = 1
 
     resolved_from, resolved_to = resolve_period(
         date_period.get("preset"),
         today=today,
-        beginning_of_week=beginning_of_week if beginning_of_week is not None else 1,
+        beginning_of_week=beginning_of_week,
         custom_from=date_period.get("from") or start_date,
         custom_to=date_period.get("to") or end_date,
     )
@@ -293,6 +315,13 @@ def build_query(
         else:
             query.pop("ordinations", None)
 
+    # A saved chart can carry the page size the UI renders it with. Sending it
+    # would return one page and give the caller no way to tell that more rows
+    # exist, since the response carries no total count. Omitting pagination
+    # returns the whole result set: measured against a 7-month ungrouped query,
+    # 7,582 rows came back, matching count(time_entry_id) for the same window.
+    query.pop("pagination", None)
+
     query.pop("v3_query_params", None)
 
     return query, local_ordinations
@@ -338,9 +367,20 @@ def resolve_rows(
     return resolved
 
 
-def _sort_value(column: str, row: Dict[str, Any]) -> str:
+def _sort_value(column: str, row: Dict[str, Any]) -> Tuple[int, float, str]:
+    """Sort key that orders numbers numerically and everything else as text.
+
+    A dropped ordination is often on an aggregate column (`sum_duration`), so
+    comparing those as strings would put 900 before 1000. The leading rank keys
+    the two kinds apart, since a tuple of mixed types cannot be compared.
+    """
     value = row.get(column)
-    return "" if value is None else str(value).lower()
+    if value is None:
+        # Nulls are repositioned after the sort; this only has to be stable.
+        return (2, 0.0, "")
+    if isinstance(value, (int, float)):  # bool included, and ordered 0 before 1
+        return (0, float(value), "")
+    return (1, 0.0, str(value).lower())
 
 
 def sort_rows(
@@ -374,7 +414,9 @@ def summarise_rows(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     totals: Dict[str, Any] = {}
     for row in rows:
         for column, value in row.items():
-            if column.startswith(("sum_", "count")) and isinstance(value, (int, float)):
+            if (column.startswith("sum_") or column == "count") and isinstance(
+                value, (int, float)
+            ):
                 totals[column] = totals.get(column, 0) + value
     if "sum_duration" in totals:
         totals["sum_duration_seconds"] = int(totals["sum_duration"]) // 1000

--- a/toggl_track_mcp/analytics.py
+++ b/toggl_track_mcp/analytics.py
@@ -15,7 +15,10 @@ Quirks of that API shape the code below:
   ``attributes`` alongside ``groupings``, and ``ordinations`` on a property that
   is not grouped (a ``client_name`` sort on a ``client_id`` grouping, for
   instance). Both return a 500 rather than a validation error, so
-  :func:`build_query` strips them and the ordering is applied locally instead.
+  :func:`build_query` strips them. When any ordination is unsendable the whole
+  sequence is applied locally by :func:`sort_rows`, because sorting part of it
+  remotely and the rest afterwards would let a secondary key override the
+  primary one.
 * A saved chart may carry the page size the UI renders it with, and a paginated
   response carries no total count. :func:`build_query` drops it so the whole
   result set comes back rather than a page that looks complete.

--- a/toggl_track_mcp/analytics.py
+++ b/toggl_track_mcp/analytics.py
@@ -227,19 +227,32 @@ def period_for_dashboard(
 ) -> Dict[str, str]:
     """Work out the date window to run a report over.
 
-    Explicit dates win; otherwise the report's saved preset is resolved.
+    A complete pair of explicit dates wins; otherwise the report's saved preset
+    is resolved.
 
     Args:
         dashboard: The report, whose preferences hold the preset and week start
-        start_date: Overrides the resolved start date
-        end_date: Overrides the resolved end date
+        start_date: Explicit start date, supplied together with ``end_date``
+        end_date: Explicit end date, supplied together with ``start_date``
         today: Reference date for relative presets (defaults to the current date)
         fallback_beginning_of_week: Week start to use when the report does not
             save one. The report's own setting always takes precedence, so that
             a week-based preset covers the same days it does in the UI whoever
             runs it.
     """
-    if start_date and end_date:
+    if (start_date is None) != (end_date is None):
+        raise ValueError("start_date and end_date must be provided together")
+
+    if start_date is not None and end_date is not None:
+        try:
+            parsed_start = date.fromisoformat(start_date)
+            parsed_end = date.fromisoformat(end_date)
+        except ValueError as error:
+            raise ValueError(
+                "start_date and end_date must use YYYY-MM-DD format"
+            ) from error
+        if parsed_start > parsed_end:
+            raise ValueError("start_date must be on or before end_date")
         return {"from": start_date, "to": end_date}
 
     preferences = dashboard.preferences or {}
@@ -301,18 +314,17 @@ def build_query(
     if groupings:
         query.pop("attributes", None)
 
-    # Sorts on a property that isn't grouped are applied locally instead.
+    # If any sort references an ungrouped property, apply the complete sequence
+    # locally. Splitting it between the API and a stable local sort would make a
+    # locally-applied secondary key override the remote primary key.
     local_ordinations: List[Dict[str, Any]] = []
     if query.get("ordinations"):
-        remote = []
-        for ordination in query["ordinations"]:
-            if ordination.get("property") in groupings:
-                remote.append(ordination)
-            else:
-                local_ordinations.append(ordination)
-        if remote:
-            query["ordinations"] = remote
-        else:
+        saved_ordinations = query["ordinations"]
+        if any(
+            ordination.get("property") not in groupings
+            for ordination in saved_ordinations
+        ):
+            local_ordinations = saved_ordinations
             query.pop("ordinations", None)
 
     # A saved chart can carry the page size the UI renders it with. Sending it

--- a/toggl_track_mcp/server.py
+++ b/toggl_track_mcp/server.py
@@ -918,6 +918,163 @@ async def create_client(
         return {"error": str(e)}
 
 
+# Custom Reports (Analytics API)
+
+
+@mcp.tool()
+async def list_custom_reports(only_pinned: bool = False) -> Dict[str, Any]:
+    """List the saved custom reports (dashboards) in the organization.
+
+    These are the multi-chart reports built in Toggl's "My Reports" section.
+    Use the returned report IDs with get_custom_report and run_custom_report.
+
+    Args:
+        only_pinned: Only return reports pinned to the Toggl sidebar
+    """
+    try:
+        client = _get_toggl_client()
+        dashboards = await client.list_dashboards(only_pinned=only_pinned)
+
+        reports = []
+        for dashboard in dashboards:
+            chart_details = (dashboard.chart_summary or {}).get("chart_details") or []
+            preferences = dashboard.preferences or {}
+            reports.append(
+                {
+                    "id": dashboard.id,
+                    "name": dashboard.name,
+                    "pinned": dashboard.pinned,
+                    "date_preset": (preferences.get("datePeriod") or {}).get("preset"),
+                    "chart_count": len(chart_details),
+                    "chart_types": [chart.get("chart_type") for chart in chart_details],
+                    "creator": dashboard.creator_name,
+                    "updated_at": dashboard.updated_at,
+                }
+            )
+
+        return {
+            "custom_reports": reports,
+            "total_count": len(reports),
+            "message": f"Found {len(reports)} custom reports",
+        }
+    except TogglAPIError as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def get_custom_report(report_id: int) -> Dict[str, Any]:
+    """Get a custom report's definition: its charts, groupings and filters.
+
+    Shows what each chart measures and how the report is filtered, which is
+    what you need to pick a chart_id for run_custom_report.
+
+    Args:
+        report_id: Custom report ID (from list_custom_reports)
+    """
+    try:
+        client = _get_toggl_client()
+        dashboard = await client.get_dashboard(report_id)
+
+        charts = []
+        for chart in dashboard.charts or []:
+            query = chart.query or {}
+            charts.append(
+                {
+                    "chart_id": chart.id,
+                    "name": chart.name,
+                    "type": chart.type,
+                    "groupings": [
+                        grouping.get("property")
+                        for grouping in query.get("groupings") or []
+                    ],
+                    "aggregations": [
+                        f"{aggregation.get('function')}({aggregation.get('property')})"
+                        for aggregation in query.get("aggregations") or []
+                    ],
+                    "filters": query.get("filters") or [],
+                }
+            )
+
+        preferences = dashboard.preferences or {}
+        return {
+            "report": {
+                "id": dashboard.id,
+                "name": dashboard.name,
+                "organization_id": dashboard.organization_id,
+                "date_preset": (preferences.get("datePeriod") or {}).get("preset"),
+                "report_filters": dashboard.filters or [],
+                "charts": charts,
+                "creator": dashboard.creator_name,
+                "updated_at": dashboard.updated_at,
+            },
+            "message": f"Custom report '{dashboard.name}' with {len(charts)} charts",
+        }
+    except TogglAPIError as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def run_custom_report(
+    report_id: int,
+    chart_id: Optional[int] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run a custom report and return its data.
+
+    Runs one chart of the report with its saved groupings and filters applied,
+    over the report's own date period unless dates are given here. IDs in the
+    results are resolved to names, and durations are returned in seconds
+    alongside the raw milliseconds the API reports.
+
+    Args:
+        report_id: Custom report ID (from list_custom_reports)
+        chart_id: Chart to run (defaults to the report's first chart)
+        start_date: Override start date in YYYY-MM-DD format
+        end_date: Override end date in YYYY-MM-DD format
+    """
+    try:
+        client = _get_toggl_client()
+        result = await client.run_dashboard_chart(
+            dashboard_id=report_id,
+            chart_id=chart_id,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        for row in result["rows"]:
+            if "sum_duration_seconds" in row:
+                row["duration_formatted"] = client.format_duration(
+                    row["sum_duration_seconds"]
+                )
+
+        totals = result["totals"]
+        if "sum_duration_seconds" in totals:
+            totals["duration_formatted"] = client.format_duration(
+                totals["sum_duration_seconds"]
+            )
+
+        period = result["period"]
+        return {
+            "report_id": result["report_id"],
+            "report_name": result["report_name"],
+            "chart_id": result["chart_id"],
+            "chart_type": result["chart_type"],
+            "period": period,
+            "rows": result["rows"],
+            "totals": totals,
+            "row_count": len(result["rows"]),
+            "message": (
+                f"'{result['report_name']}' returned {len(result['rows'])} rows "
+                f"for {period['from']} to {period['to']}"
+            ),
+        }
+    except TogglAPIError as e:
+        return {"error": str(e)}
+    except ValueError as e:
+        return {"error": str(e)}
+
+
 # FastAPI application setup
 def create_app() -> FastAPI:
     """Create FastAPI application with MCP integration."""

--- a/toggl_track_mcp/server.py
+++ b/toggl_track_mcp/server.py
@@ -1030,8 +1030,8 @@ async def run_custom_report(
     Args:
         report_id: Custom report ID (from list_custom_reports)
         chart_id: Chart to run (defaults to the report's first chart)
-        start_date: Override start date in YYYY-MM-DD format
-        end_date: Override end date in YYYY-MM-DD format
+        start_date: Override start date in YYYY-MM-DD format (requires end_date)
+        end_date: Override end date in YYYY-MM-DD format (requires start_date)
     """
     try:
         client = _get_toggl_client()

--- a/toggl_track_mcp/toggl_client.py
+++ b/toggl_track_mcp/toggl_client.py
@@ -228,6 +228,7 @@ class TogglAPIClient:
         self.base_url = base_url.rstrip("/")
         self.workspace_id = workspace_id
         self.rate_limiter = TokenBucketRateLimiter(requests_per_second, burst_size)
+        self._organization_id: Optional[int] = None
 
         # Create auth header
         auth_string = f"{api_token}:api_token"
@@ -311,7 +312,11 @@ class TogglAPIClient:
                     return result  # type: ignore[no-any-return]
 
             except httpx.HTTPStatusError as e:
-                if attempt == retries:
+                # A 4xx is the server rejecting the request itself (bad payload,
+                # no permission, no such resource) and will fail identically on
+                # retry, so surface it rather than backing off three times.
+                is_client_error = 400 <= e.response.status_code < 500
+                if attempt == retries or is_client_error:
                     error_msg = f"HTTP {e.response.status_code}: {e.response.text}"
                     raise TogglAPIError(error_msg, status_code=e.response.status_code)
                 await asyncio.sleep(2**attempt)  # Exponential backoff
@@ -781,14 +786,21 @@ class TogglAPIClient:
         """Get the organization ID that owns a workspace.
 
         Custom reports are scoped to an organization, not a workspace, but the
-        workspace is what callers usually have to hand.
+        workspace is what callers usually have to hand. Resolving it costs two
+        requests, so the default workspace's organization is cached.
         """
+        if not workspace_id and self._organization_id is not None:
+            return self._organization_id
+
+        requested_id = workspace_id
         if not workspace_id:
             user = await self.get_current_user()
             workspace_id = self.workspace_id or user.default_workspace_id
 
         for workspace in await self.get_workspaces():
             if workspace.id == workspace_id and workspace.organization_id:
+                if requested_id is None:
+                    self._organization_id = workspace.organization_id
                 return workspace.organization_id
 
         raise TogglAPIError(f"No organization found for workspace {workspace_id}")
@@ -894,12 +906,19 @@ class TogglAPIClient:
                 )
             chart = matches[0]
 
-        user = await self.get_current_user()
+        # Only a relative preset needs a week start, and the report's own
+        # setting wins over the caller's, so skip the /me call when both dates
+        # are given.
+        fallback_beginning_of_week = None
+        if not (start_date and end_date):
+            user = await self.get_current_user()
+            fallback_beginning_of_week = user.beginning_of_week
+
         period = period_for_dashboard(
             dashboard,
             start_date=start_date,
             end_date=end_date,
-            beginning_of_week=user.beginning_of_week,
+            fallback_beginning_of_week=fallback_beginning_of_week,
         )
 
         query, local_ordinations = build_query(dashboard, chart, period)

--- a/toggl_track_mcp/toggl_client.py
+++ b/toggl_track_mcp/toggl_client.py
@@ -3,7 +3,9 @@
 import asyncio
 import base64
 import logging
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
 from pydantic import BaseModel, ConfigDict
@@ -910,14 +912,24 @@ class TogglAPIClient:
         # setting wins over the caller's, so skip the /me call when both dates
         # are given.
         fallback_beginning_of_week = None
+        today: Optional[date] = None
         if not (start_date and end_date):
             user = await self.get_current_user()
             fallback_beginning_of_week = user.beginning_of_week
+            try:
+                today = datetime.now(ZoneInfo(user.timezone)).date()
+            except ZoneInfoNotFoundError:
+                logger.warning(
+                    "Unknown Toggl timezone %r; using the server's local date",
+                    user.timezone,
+                )
+                today = date.today()
 
         period = period_for_dashboard(
             dashboard,
             start_date=start_date,
             end_date=end_date,
+            today=today,
             fallback_beginning_of_week=fallback_beginning_of_week,
         )
 

--- a/toggl_track_mcp/toggl_client.py
+++ b/toggl_track_mcp/toggl_client.py
@@ -8,6 +8,16 @@ from typing import Any, Dict, List, Optional, Union
 import httpx
 from pydantic import BaseModel, ConfigDict
 
+from .analytics import (
+    ANALYTICS_BASE_URL,
+    TogglAnalyticsChart,
+    TogglAnalyticsDashboard,
+    build_query,
+    period_for_dashboard,
+    resolve_rows,
+    sort_rows,
+    summarise_rows,
+)
 from .rate_limiter import TokenBucketRateLimiter
 
 logger = logging.getLogger(__name__)
@@ -232,6 +242,7 @@ class TogglAPIClient:
         params: Optional[Dict[str, Any]] = None,
         json_data: Optional[Dict[str, Any]] = None,
         retries: int = 3,
+        base_url: Optional[str] = None,
     ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """Make an authenticated request to the Toggl API.
 
@@ -241,6 +252,8 @@ class TogglAPIClient:
             params: Query parameters
             json_data: JSON body data
             retries: Number of retries for rate limiting
+            base_url: Override the client's base URL (used for the Analytics API,
+                which is served from a different path than the v9 API)
 
         Returns:
             Response data as dict or list
@@ -250,7 +263,7 @@ class TogglAPIClient:
         """
         await self.rate_limiter.acquire()
 
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        url = f"{(base_url or self.base_url).rstrip('/')}/{endpoint.lstrip('/')}"
         headers = {
             "Authorization": self.auth_header,
             "Content-Type": "application/json",
@@ -758,3 +771,156 @@ class TogglAPIClient:
                 except Exception:
                     error_msg += f" - {response.text}"
                 raise TogglAPIError(error_msg, response.status_code)
+
+    # Analytics API Methods (Custom Reports)
+    #
+    # Custom reports are organization-scoped dashboards. See analytics.py for
+    # what this API is and why it needs handling of its own.
+
+    async def get_organization_id(self, workspace_id: Optional[int] = None) -> int:
+        """Get the organization ID that owns a workspace.
+
+        Custom reports are scoped to an organization, not a workspace, but the
+        workspace is what callers usually have to hand.
+        """
+        if not workspace_id:
+            user = await self.get_current_user()
+            workspace_id = self.workspace_id or user.default_workspace_id
+
+        for workspace in await self.get_workspaces():
+            if workspace.id == workspace_id and workspace.organization_id:
+                return workspace.organization_id
+
+        raise TogglAPIError(f"No organization found for workspace {workspace_id}")
+
+    async def list_dashboards(
+        self,
+        organization_id: Optional[int] = None,
+        only_pinned: bool = False,
+    ) -> List[TogglAnalyticsDashboard]:
+        """List the custom reports in an organization.
+
+        Args:
+            organization_id: Organization ID (resolved from the workspace if omitted)
+            only_pinned: Return only reports pinned to the sidebar
+        """
+        if not organization_id:
+            organization_id = await self.get_organization_id()
+
+        params: Dict[str, Any] = {"organization_id": organization_id}
+        if only_pinned:
+            params["pinned"] = "true"
+
+        data = await self._make_request(
+            "GET", "/dashboards", params=params, base_url=ANALYTICS_BASE_URL
+        )
+        if isinstance(data, list):
+            return [TogglAnalyticsDashboard(**dashboard) for dashboard in data]
+        raise TogglAPIError("Invalid response format for custom reports")
+
+    async def get_dashboard(self, dashboard_id: int) -> TogglAnalyticsDashboard:
+        """Get a custom report's full definition, including its charts."""
+        data = await self._make_request(
+            "GET", f"/dashboards/{dashboard_id}", base_url=ANALYTICS_BASE_URL
+        )
+        if isinstance(data, dict):
+            return TogglAnalyticsDashboard(**data)
+        raise TogglAPIError("Invalid response format for custom report")
+
+    async def run_analytics_query(
+        self,
+        organization_id: int,
+        query: Dict[str, Any],
+        include_dicts: bool = True,
+    ) -> Dict[str, Any]:
+        """Run a query against the analytics engine.
+
+        Args:
+            organization_id: Organization the query runs against
+            query: Query payload (period, groupings, aggregations, filters)
+            include_dicts: Ask for the id-to-name dictionaries alongside the rows
+        """
+        data = await self._make_request(
+            "POST",
+            f"/organizations/{organization_id}/query",
+            params={
+                "response_format": "json_row",
+                "include_dicts": "true" if include_dicts else "false",
+            },
+            json_data=query,
+            base_url=ANALYTICS_BASE_URL,
+        )
+        if isinstance(data, dict):
+            return data
+        raise TogglAPIError("Invalid response format for analytics query")
+
+    async def run_dashboard_chart(
+        self,
+        dashboard_id: int,
+        chart_id: Optional[int] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        dashboard: Optional[TogglAnalyticsDashboard] = None,
+    ) -> Dict[str, Any]:
+        """Run one chart of a custom report and return its rows.
+
+        Reproduces what the report shows: the chart's saved query, the
+        report-level filters, and either the report's saved period or the dates
+        given here.
+
+        Args:
+            dashboard_id: Custom report ID
+            chart_id: Chart to run (defaults to the report's first chart)
+            start_date: Override start date (YYYY-MM-DD)
+            end_date: Override end date (YYYY-MM-DD)
+            dashboard: Already-fetched report, to save a round trip
+        """
+        if dashboard is None:
+            dashboard = await self.get_dashboard(dashboard_id)
+
+        charts: List[TogglAnalyticsChart] = dashboard.charts or []
+        if not charts:
+            raise TogglAPIError(f"Custom report {dashboard_id} has no charts")
+
+        if chart_id is None:
+            chart = charts[0]
+        else:
+            matches = [chart for chart in charts if chart.id == chart_id]
+            if not matches:
+                available = ", ".join(str(chart.id) for chart in charts)
+                raise TogglAPIError(
+                    f"Chart {chart_id} is not part of custom report "
+                    f"{dashboard_id} (charts: {available})"
+                )
+            chart = matches[0]
+
+        user = await self.get_current_user()
+        period = period_for_dashboard(
+            dashboard,
+            start_date=start_date,
+            end_date=end_date,
+            beginning_of_week=user.beginning_of_week,
+        )
+
+        query, local_ordinations = build_query(dashboard, chart, period)
+
+        organization_id = dashboard.organization_id
+        if not organization_id:
+            organization_id = await self.get_organization_id()
+
+        response = await self.run_analytics_query(organization_id, query)
+        rows = resolve_rows(
+            response.get("data_json_row") or [], response.get("dictionaries")
+        )
+        rows = sort_rows(rows, local_ordinations)
+
+        return {
+            "report_id": dashboard_id,
+            "report_name": dashboard.name,
+            "chart_id": chart.id,
+            "chart_type": chart.type,
+            "period": period,
+            "rows": rows,
+            "totals": summarise_rows(rows),
+            "query": query,
+        }


### PR DESCRIPTION
## What and why

The custom reports built in Toggl's **My Reports** section (`track.toggl.com/reports/{organization_id}/custom/{report_id}`) were unreachable from this server. They are not part of the v9 or Reports v3 APIs it wraps — Toggl serves them from a separate `analytics` API with its own resource model (organization-scoped *dashboards* containing *charts*).

That API is undocumented: there is no OpenAPI spec and nothing in the published docs. The endpoints here were read out of the Toggl web app's own API client and then verified against the live API. It authenticates with the ordinary API token, so no new configuration is needed, but it is unversioned and Toggl can change it without notice — hence keeping it behind its own module.

## Tools added

All read-only. None of them modify a report.

| Tool | Returns |
|---|---|
| `list_custom_reports(only_pinned=False)` | Saved reports with id, name, chart types, saved date preset, creator |
| `get_custom_report(report_id)` | Each chart's groupings, aggregations and filters, plus the report-level filters |
| `run_custom_report(report_id, chart_id=None, start_date=None, end_date=None)` | One chart's rows, ids resolved to names, durations in seconds and formatted, plus totals |

`run_custom_report` uses the report's saved date period unless dates are passed, and defaults to the first chart.

## Implementation notes

`toggl_track_mcp/analytics.py` holds the models and pure helpers; the HTTP methods sit on `TogglAPIClient` alongside the existing ones. Three behaviours of that API needed handling:

- **Durations are milliseconds**, not seconds as in Reports v3. `resolve_rows` adds a `*_seconds` column rather than silently changing units.
- **The query engine returns a 500, not a validation error**, for `attributes` alongside `groupings`, and for an ordination over a property that isn't grouped — both of which a saved chart can legitimately contain. `build_query` strips them; `sort_rows` reapplies the dropped ordering locally, after ids have been resolved to names, so a `client_name` sort still works.
- **Reports store a date preset** (`prevMonth`, `lastSemester`, …) rather than dates. `resolve_period` mirrors the web app's own preset definitions, including quarter and half-year boundaries and the user's start-of-week, so a run covers the same days the UI shows.

`_make_request` takes a `base_url` override for the analytics host instead of a third copy of the httpx block.

## Testing

- 80 new tests: 57 for the helpers (`analytics.py` at 100% coverage), 15 for the client methods, 8 for the tools. Suite is 191 tests, total coverage 90.94%.
- `ruff`, `black --check`, `isort --check-only` and `mypy` all clean on the package.
- Verified end to end against a live workspace: listing, definition, a run over the saved period and a run with explicit dates all returned correct data, and the totals reconciled against the same query issued by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)